### PR TITLE
Fix wait method to accept milliseconds

### DIFF
--- a/src/WebDriver.php
+++ b/src/WebDriver.php
@@ -1202,7 +1202,7 @@ EOF;
 
     public function wait($timeout, $condition)
     {
-        $seconds = (int) ($timeout / 1000.0);
+        $seconds = $timeout / 1000.0;
         $wait = $this->webDriver->wait($seconds);
 
         if (is_string($condition)) {


### PR DESCRIPTION
In a recent update #79, the `wait` method started rounding milliseconds to seconds and I'm not sure that it was intentional (after all, if the `wait` method is only supposed to take seconds, it should take an `int $seconds` argument instead).