### PR TITLE
Reset driver connection even if stopping the driver fails

### DIFF
--- a/src/WebDriver.php
+++ b/src/WebDriver.php
@@ -289,9 +289,11 @@ class WebDriver extends CoreDriver
 
         try {
             $this->webDriver->quit();
-            $this->webDriver = null;
         } catch (\Exception $e) {
             throw new DriverException('Could not close connection', 0, $e);
+        } finally {
+            // Note: The finally section will be executed before the DriverException is thrown.
+            $this->webDriver = null;
         }
     }
 


### PR DESCRIPTION
This change ensures that if an error occurs whilst stopping the driver, that the current driver is still discarded and does not impact subsequent tests.

We have experienced issues when testing large datasets whereby the page takes a significant amount of time to load, blocking the driver. As a result the connection timeout is encountered, and the Behat Scenario fails.

We also restart the browser between every test to ensure that all caches are cleared. We do this in a Behat hook.

When we come to restart the connection and start the next test the WebDriver connection is still hung causing another exception to be thrown during the reset and no way to discard the session and start a new one.

Generally this happens very rarely, but when it does happen it currently causes the entire testrun to be aborted and a rerun runs the entire testsuite rather than just the test that originally caused the failure.